### PR TITLE
Update nfd-autoreg.upstart

### DIFF
--- a/nfd/debian/nfd-autoreg.upstart
+++ b/nfd/debian/nfd-autoreg.upstart
@@ -10,6 +10,7 @@ respawn limit unlimited
 setuid ndn
 setgid ndn
 
+pre-start exec sleep 2
 script
   BLACKLIST=""
   WHITELIST=""


### PR DESCRIPTION
pre-start sleep change added by John DeHart on NDN Testbed nodes to keep nfd-autoreg
from starting before nrd.
